### PR TITLE
Add canonical embedding during refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ are implemented in this repo as well (ticked boxes) and which are not (yet) (unt
 - [ ] `solveLaplace0.m`
 - [ ] `solveLaplace1.m`
 
-Also, this repo includes some functionalities that were not provided in the original MATLAB code.
-The most important of which is the assembly of the mass matrix,
-which is implemented along the same lines as the assembly of the stiffness matrix.
+Also, this repo includes some functionalities that were not provided in the original MATLAB code:
+- Assembly of Mass Matrix along the same lines as assembly of stiffness matrix.
+- Linear Interpolation of values on coordinates onto new nodes after refinement.
+- Red refinement algorithm, where (yet) only a single element can be marked.
 
 ## Data structures
 

--- a/p1afempy/refinement.py
+++ b/p1afempy/refinement.py
@@ -15,16 +15,16 @@ def generate_new_nodes(edge2newNode: np.ndarray,
     edge2newNode[edge2newNode != 0] = np.arange(
         coordinates.shape[0],
         coordinates.shape[0] + n_new_nodes)
-    idx = np.nonzero(edge2newNode)[0]
+    edges_with_new_nodes_indices = np.nonzero(edge2newNode)[0]
     new_node_coordinates = (
-        coordinates[edge2nodes[idx, 0], :] +
-        coordinates[edge2nodes[idx, 1], :]) / 2.
+        coordinates[edge2nodes[edges_with_new_nodes_indices, 0], :] +
+        coordinates[edge2nodes[edges_with_new_nodes_indices, 1], :]) / 2.
 
     # interpolate values, if given
     if to_embed.size:
         new_embedded_values = (
-            to_embed[edge2nodes[idx, 0], :] +
-            to_embed[edge2nodes[idx, 1], :]) / 2.
+            to_embed[edge2nodes[edges_with_new_nodes_indices, 0], :] +
+            to_embed[edge2nodes[edges_with_new_nodes_indices, 1], :]) / 2.
         to_embed = np.vstack([to_embed, new_embedded_values])
 
     return np.vstack([coordinates, new_node_coordinates]), to_embed

--- a/p1afempy/refinement.py
+++ b/p1afempy/refinement.py
@@ -21,14 +21,13 @@ def generate_new_nodes(edge2newNode: np.ndarray,
         coordinates[edge2nodes[idx, 1], :]) / 2.
 
     # interpolate values, if given
-    # ----------------------------
-    # TODO implement
-    embedded_values = np.array([])
     if to_embed.size:
-        pass
-    # ----------------------------
+        new_embedded_values = (
+            to_embed[edge2nodes[idx, 0], :] +
+            to_embed[edge2nodes[idx, 1], :]) / 2.
+        to_embed = np.vstack([to_embed, new_embedded_values])
 
-    return np.vstack([coordinates, new_node_coordinates]), embedded_values
+    return np.vstack([coordinates, new_node_coordinates]), to_embed
 
 
 def refineRG(coordinates: CoordinatesType,

--- a/p1afempy/refinement.py
+++ b/p1afempy/refinement.py
@@ -23,9 +23,9 @@ def generate_new_nodes(edge2newNode: np.ndarray,
     # interpolate values, if given
     if to_embed.size:
         new_embedded_values = (
-            to_embed[edge2nodes[edges_with_new_nodes_indices, 0], :] +
-            to_embed[edge2nodes[edges_with_new_nodes_indices, 1], :]) / 2.
-        to_embed = np.vstack([to_embed, new_embedded_values])
+            to_embed[edge2nodes[edges_with_new_nodes_indices, 0]] +
+            to_embed[edge2nodes[edges_with_new_nodes_indices, 1]]) / 2.
+        to_embed = np.hstack([to_embed, new_embedded_values])
 
     return np.vstack([coordinates, new_node_coordinates]), to_embed
 

--- a/p1afempy/tests/auto/test_indicators.py
+++ b/p1afempy/tests/auto/test_indicators.py
@@ -30,7 +30,7 @@ class IndicatorTest(unittest.TestCase):
         n_refinements = 2
         for _ in range(n_refinements):
             marked_elements = np.arange(elements.shape[0])
-            coordinates, elements, boundary_conditions = \
+            coordinates, elements, boundary_conditions, _ = \
                 refinement.refineNVB(coordinates=coordinates,
                                      elements=elements,
                                      marked_elements=marked_elements,

--- a/p1afempy/tests/auto/test_mesh.py
+++ b/p1afempy/tests/auto/test_mesh.py
@@ -116,7 +116,7 @@ class MeshTest(unittest.TestCase):
                                boundary_condition_1]
         coordinates, elements = MeshTest.get_simple_square_mesh()
 
-        refined_coordinates, refined_elements, new_boundaries = \
+        refined_coordinates, refined_elements, new_boundaries, _ = \
             refinement.refineNVB(coordinates=coordinates,
                                  elements=elements,
                                  marked_elements=np.array([0, 1]),
@@ -168,7 +168,7 @@ class MeshTest(unittest.TestCase):
             path_to_coordinates=path_to_coordinates,
             path_to_elements=path_to_elements)
         marked_elements = np.array([0, 1, 3, 5])
-        refined_coordinates, refined_elements, new_boundaries = \
+        refined_coordinates, refined_elements, new_boundaries, _ = \
             refinement.refineNVB(
                 coordinates=coordinates,
                 elements=elements,
@@ -216,7 +216,7 @@ class MeshTest(unittest.TestCase):
             path_to_coordinates=path_to_coordinates,
             path_to_elements=path_to_elements)
         marked_elements = np.array([0, 1, 3, 5])
-        refined_coordinates, refined_elements, new_boundaries = \
+        refined_coordinates, refined_elements, new_boundaries, _ = \
             refinement.refineRGB(
                 coordinates=coordinates,
                 elements=elements,

--- a/p1afempy/tests/auto/test_refinement.py
+++ b/p1afempy/tests/auto/test_refinement.py
@@ -34,7 +34,7 @@ class RefinementTest(unittest.TestCase):
         # ----------------
         marked_element = 3
 
-        new_coordinates, new_elements, new_boundaries = \
+        new_coordinates, new_elements, new_boundaries, _ = \
             refinement.refineRG(
                 coordinates=coordinates,
                 elements=elements,
@@ -70,7 +70,7 @@ class RefinementTest(unittest.TestCase):
         # --------------
         marked_element = 0
 
-        new_coordinates, new_elements, new_boundaries = \
+        new_coordinates, new_elements, new_boundaries, _ = \
             refinement.refineRG(
                 coordinates=coordinates,
                 elements=elements,
@@ -106,7 +106,7 @@ class RefinementTest(unittest.TestCase):
         # ------------
         marked_element = 5
 
-        new_coordinates, new_elements, new_boundaries = \
+        new_coordinates, new_elements, new_boundaries, _ = \
             refinement.refineRG(
                 coordinates=coordinates,
                 elements=elements,

--- a/p1afempy/tests/auto/test_sanity_check.py
+++ b/p1afempy/tests/auto/test_sanity_check.py
@@ -93,7 +93,7 @@ class SanityChecks(unittest.TestCase):
             marked_elements = np.arange(elements.shape[0])
 
             # perform refinement
-            coordinates, elements, boundaries = refinement.refineNVB(
+            coordinates, elements, boundaries, _ = refinement.refineNVB(
                 coordinates=coordinates,
                 elements=elements,
                 marked_elements=marked_elements,
@@ -116,7 +116,7 @@ class SanityChecks(unittest.TestCase):
             marked_elements = np.arange(elements.shape[0])
 
             # perform refinement
-            coordinates, elements, boundaries = refinement.refineRGB(
+            coordinates, elements, boundaries, _ = refinement.refineRGB(
                 coordinates=coordinates,
                 elements=elements,
                 marked_elements=marked_elements,

--- a/p1afempy/tests/auto/test_sanity_check.py
+++ b/p1afempy/tests/auto/test_sanity_check.py
@@ -136,7 +136,7 @@ class SanityChecks(unittest.TestCase):
             marked_element = random.randrange(n_elements)
 
             # perform refinement
-            coordinates, elements, boundaries = refinement.refineRG(
+            coordinates, elements, boundaries, _ = refinement.refineRG(
                 coordinates=coordinates,
                 elements=elements,
                 marked_element=marked_element,

--- a/p1afempy/tests/auto/test_sanity_check.py
+++ b/p1afempy/tests/auto/test_sanity_check.py
@@ -86,6 +86,9 @@ class SanityChecks(unittest.TestCase):
     def test_refine_nvb(self) -> None:
         coordinates, elements, dirichlet = SanityChecks.get_initial_mesh()
 
+        # initial vector of values to be interpolated on refined meshes
+        to_embed = np.array([test_function(x, y) for (x, y) in coordinates])
+
         boundaries = [dirichlet]
         n_refinements = 5
         for _ in range(n_refinements):
@@ -93,22 +96,31 @@ class SanityChecks(unittest.TestCase):
             marked_elements = np.arange(elements.shape[0])
 
             # perform refinement
-            coordinates, elements, boundaries, _ = refinement.refineNVB(
+            coordinates, elements, boundaries, to_embed = refinement.refineNVB(
                 coordinates=coordinates,
                 elements=elements,
                 marked_elements=marked_elements,
-                boundary_conditions=boundaries)
+                boundary_conditions=boundaries,
+                to_embed=to_embed)
 
             # in each step, compare the computed vs. expected eenergy
             expected_energy = 4.
+
             computed_energy = evaluate_energy_on_mesh(
                 coordinates=coordinates, elements=elements)
-
             self.assertEqual(expected_energy, computed_energy)
+
+            computed_interpolated_energy = evaluate_energy_on_mesh(
+                coordinates=coordinates, elements=elements,
+                test_function_vector=to_embed)
+            self.assertEqual(expected_energy, computed_interpolated_energy)
 
     def test_refine_rgb(self) -> None:
         coordinates, elements, dirichlet = SanityChecks.get_initial_mesh()
 
+        # initial vector of values to be interpolated on refined meshes
+        to_embed = np.array([test_function(x, y) for (x, y) in coordinates])
+
         boundaries = [dirichlet]
         n_refinements = 5
         for _ in range(n_refinements):
@@ -116,18 +128,24 @@ class SanityChecks(unittest.TestCase):
             marked_elements = np.arange(elements.shape[0])
 
             # perform refinement
-            coordinates, elements, boundaries, _ = refinement.refineRGB(
+            coordinates, elements, boundaries, to_embed = refinement.refineRGB(
                 coordinates=coordinates,
                 elements=elements,
                 marked_elements=marked_elements,
-                boundary_conditions=boundaries)
+                boundary_conditions=boundaries,
+                to_embed=to_embed)
 
             # in each step, compare the computed vs. expected eenergy
             expected_energy = 4.
+
             computed_energy = evaluate_energy_on_mesh(
                 coordinates=coordinates, elements=elements)
-
             self.assertEqual(expected_energy, computed_energy)
+
+            computed_interpolated_energy = evaluate_energy_on_mesh(
+                coordinates=coordinates, elements=elements,
+                test_function_vector=to_embed)
+            self.assertEqual(expected_energy, computed_interpolated_energy)
 
     def test_refine_rg(self) -> None:
         random.seed(42)

--- a/p1afempy/tests/auto/test_solver.py
+++ b/p1afempy/tests/auto/test_solver.py
@@ -31,7 +31,7 @@ class SolverTest(unittest.TestCase):
         n_refinements = 3
         for _ in range(n_refinements):
             marked_elements = np.arange(elements.shape[0])
-            coordinates, elements, boundary_conditions = refinement.refineNVB(
+            coordinates, elements, boundary_conditions, _ = refinement.refineNVB(
                 coordinates=coordinates,
                 elements=elements,
                 marked_elements=marked_elements,

--- a/p1afempy/tests/manual/performance_test_refineNVB.py
+++ b/p1afempy/tests/manual/performance_test_refineNVB.py
@@ -40,17 +40,17 @@ def main() -> None:
         for _ in range(n_repetetitions_each):
             start_time = time.process_time_ns()
             # refine and throw away the result
-            _, _, _ = refinement.refineNVB(coordinates=coordinates,
-                                           elements=elements,
-                                           marked_elements=marked_elements,
-                                           boundary_conditions=boundaries)
+            _, _, _, _ = refinement.refineNVB(coordinates=coordinates,
+                                              elements=elements,
+                                              marked_elements=marked_elements,
+                                              boundary_conditions=boundaries)
             end_time = time.process_time_ns()
             test_result.add_time(time=(end_time - start_time)*1e-9)
 
         test_results.append(copy.deepcopy(test_result))
 
         # actually keep refinement's result to get next iteration step
-        coordinates, elements, boundaries = refinement.refineNVB(
+        coordinates, elements, boundaries, _ = refinement.refineNVB(
             coordinates=coordinates,
             elements=elements,
             marked_elements=marked_elements,

--- a/p1afempy/tests/manual/performance_test_solve_laplace.py
+++ b/p1afempy/tests/manual/performance_test_solve_laplace.py
@@ -37,7 +37,7 @@ def main() -> None:
     for _ in range(n_refinements):
         # refine all elements
         marked_elements = np.arange(elements.shape[0])
-        coordinates, elements, boundaries = refinement.refineNVB(
+        coordinates, elements, boundaries, _ = refinement.refineNVB(
             coordinates=coordinates,
             elements=elements,
             marked_elements=marked_elements,

--- a/p1afempy/tests/manual/performance_test_stiffnes_matrix.py
+++ b/p1afempy/tests/manual/performance_test_stiffnes_matrix.py
@@ -45,7 +45,7 @@ def main() -> None:
 
         test_results.append(copy.deepcopy(test_result))
         marked_elements = np.arange(n_elements)  # refine all elements
-        coordinates, elements, boundaries = refinement.refineNVB(
+        coordinates, elements, boundaries, _ = refinement.refineNVB(
             coordinates=coordinates,
             elements=elements,
             marked_elements=marked_elements,

--- a/p1afempy/tests/manual/test_refine_rg.py
+++ b/p1afempy/tests/manual/test_refine_rg.py
@@ -29,7 +29,7 @@ def main() -> None:
     # ----------------
     marked_element = 3
 
-    new_coordinates, new_elements, new_boundaries = \
+    new_coordinates, new_elements, new_boundaries, _ = \
         refinement.refineRG(
             coordinates=coordinates,
             elements=elements,


### PR DESCRIPTION
This PR allows for the canonical embedding of a vector onto a refined mesh during refinement,
i.e. for each marked edge, we linearly interpolate the neighboring nodes' values onto the new node.