### PR TITLE
evaluate P1FEM function on any admissible coordinates

### DIFF
--- a/p1afempy/solvers.py
+++ b/p1afempy/solvers.py
@@ -727,6 +727,54 @@ def evaluate_on_coordinates(
     then, this routine returns a vector `u_tilde`
     of length N, given by u_tilde_j := u(z_j).
     """
-    #TODO implement
-    n_coordinates = r.shape[0]
-    return np.zeros(n_coordinates)
+
+    determinants = 2.*get_area(
+        coordinates=coordinates,
+        elements=elements)
+    
+    x1 = coordinates[elements[:, 0], 0]
+    x2 = coordinates[elements[:, 1], 0]
+    x3 = coordinates[elements[:, 2], 0]
+    y1 = coordinates[elements[:, 0], 1]
+    y2 = coordinates[elements[:, 1], 1]
+    y3 = coordinates[elements[:, 2], 1]
+
+    u_tilde = np.zeros(r.shape[0])
+    for k, z in enumerate(r):
+        x, y = z
+
+        lambdas_1 = (
+            (y2 - y3)*(x - x3)
+            +
+            (x3 - x2)*(y - y3)
+        )/determinants
+
+        lambdas_2 = (
+            (y3 - y1)*(x - x3)
+            +
+            (x1 - x3)*(y - y3)
+        )/determinants
+
+        lambdas_3 = 1. - lambdas_1 - lambdas_2
+
+        lambdas = np.column_stack([
+            lambdas_1, lambdas_2, lambdas_3
+        ])
+
+        indicators = np.sum(lambdas >= 0., axis=1)
+
+        index_of_element = np.argmax(indicators)
+
+        l1, l2, l3 = lambdas[index_of_element, :]
+
+        u_1, u_2, u_3 = u[elements[index_of_element, :]]
+
+        u_tilde[k] = (
+            l1 * u_1
+            +
+            l2 * u_2
+            +
+            l3 * u_3
+        )
+
+    return u_tilde

--- a/p1afempy/solvers.py
+++ b/p1afempy/solvers.py
@@ -9,6 +9,7 @@ from triangle_cubature.rule_factory import get_rule
 from itertools import product
 from triangle_cubature.rule_factory import get_rule
 from collections.abc import Callable
+from tqdm import tqdm
 
 
 def get_stiffness_matrix(coordinates: CoordinatesType,
@@ -700,7 +701,8 @@ def evaluate_on_coordinates(
         u: np.ndarray,
         elements: ElementsType,
         coordinates: CoordinatesType,
-        r: CoordinatesType
+        r: CoordinatesType,
+        display_progress_bar: bool = False
 ) -> np.ndarray:
     """
     evaluates the P1FEM function `u`
@@ -740,8 +742,8 @@ def evaluate_on_coordinates(
     y3 = coordinates[elements[:, 2], 1]
 
     u_tilde = np.zeros(r.shape[0])
-    for k, z in enumerate(r):
-        x, y = z
+    for k in tqdm(range(r.shape[0]), disable=not display_progress_bar):
+        x, y = r[k]
 
         lambdas_1 = (
             (y2 - y3)*(x - x3)

--- a/p1afempy/solvers.py
+++ b/p1afempy/solvers.py
@@ -694,3 +694,39 @@ def solve_laplace(coordinates: CoordinatesType,
     energy = x.dot(A.dot(x))
 
     return x, energy
+
+
+def evaluate_on_coordinates(
+        u: np.ndarray,
+        elements: ElementsType,
+        coordinates: CoordinatesType,
+        r: CoordinatesType
+) -> np.ndarray:
+    """
+    evaluates the P1FEM function `u`
+    living on the mesh given by
+    `coordinates` and `elements`
+    on the coordinates given by `r`
+
+    parameters
+    ----------
+    u: np.ndarray
+        a P1 FEM vector living on the mesh
+        given by `coordinates_H` and `elements_H`
+    elements: ElementsType
+        the elements of the mesh we wish to transfer from
+    coordinates: CoordinatesType
+        the coordinates of the mesh we wish to transfer from
+    r: CoordinatesType
+        the coordinates on which we wish
+        to evaluate u_H in P1(T_H)
+    
+    notes
+    -----
+    let N denote the number of coordinates in `r`.
+    then, this routine returns a vector `u_tilde`
+    of length N, given by u_tilde_j := u(z_j).
+    """
+    #TODO implement
+    n_coordinates = r.shape[0]
+    return np.zeros(n_coordinates)

--- a/p1afempy/solvers.py
+++ b/p1afempy/solvers.py
@@ -725,9 +725,15 @@ def evaluate_on_coordinates(
     
     notes
     -----
-    let N denote the number of coordinates in `r`.
-    then, this routine returns a vector `u_tilde`
-    of length N, given by u_tilde_j := u(z_j).
+    - let N denote the number of coordinates in `r`.
+      then, this routine returns a vector `u_tilde`
+      of length N, given by u_tilde_j := u(z_j).
+    - it is implicitly assumed that all the points
+      in `r` lie in the domain Omega
+    - the idea of this implementation is that
+      we calculate barycentric coordinates lambda_j
+      and note that, if r_i lies in or on the triangle T,
+      we have lambda_j >= 0.
     """
 
     determinants = 2.*get_area(

--- a/p1afempy/tests/auto/test_evaluate_on_coordinates.py
+++ b/p1afempy/tests/auto/test_evaluate_on_coordinates.py
@@ -57,7 +57,8 @@ class GeneralStiffnessMatrixTest(unittest.TestCase):
                 u=u,
                 elements=old_elements,
                 coordinates=old_coordinates,
-                r=new_coordinates)
+                r=new_coordinates,
+                display_progress_bar=False)
             
             current_a_norm_squared = u.dot(stiffness_matrix.dot(u))
 

--- a/p1afempy/tests/auto/test_evaluate_on_coordinates.py
+++ b/p1afempy/tests/auto/test_evaluate_on_coordinates.py
@@ -17,7 +17,7 @@ class GeneralStiffnessMatrixTest(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    def test_evaluate_on_mesh(self) -> None:
+    def test_evaluate_on_coordinates(self) -> None:
         n_initial_refinements = 3
         n_test_refinements = 5
 

--- a/p1afempy/tests/auto/test_evaluate_on_coordinates.py
+++ b/p1afempy/tests/auto/test_evaluate_on_coordinates.py
@@ -1,0 +1,103 @@
+import numpy as np
+import unittest
+from p1afempy.data_structures import BoundaryType, ElementsType, CoordinatesType
+from p1afempy.refinement import refineNVB
+from p1afempy.solvers import get_stiffness_matrix
+from p1afempy.solvers import evaluate_on_coordinates
+from scipy.sparse import csr_matrix
+
+
+class GeneralStiffnessMatrixTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(42)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_evaluate_on_mesh(self) -> None:
+        n_initial_refinements = 3
+        n_test_refinements = 5
+
+        elements, coordinates, boundaries = get_initial_mesh()
+
+        for _ in range(n_initial_refinements):
+            marked_elements = np.arange(elements.shape[0])
+            coordinates, elements, boundaries, _ = \
+                refineNVB(coordinates=coordinates,
+                                        elements=elements,
+                                        marked_elements=marked_elements,
+                                        boundary_conditions=boundaries)
+
+        old_coordinates = coordinates
+        old_elements = elements
+        old_boundaries = boundaries
+
+        n_initial_coordinates = coordinates.shape[0]
+        u = np.random.rand(n_initial_coordinates) * 10.
+
+        stiffness_matrix = csr_matrix(get_stiffness_matrix(
+            coordinates=coordinates, elements=elements))
+        initial_a_norm_squared = u.dot(stiffness_matrix.dot(u))
+
+        for _ in range(n_test_refinements):
+            marked_elements = np.arange(elements.shape[0])
+            new_coordinates, new_elements, new_boundaries, _ = \
+                refineNVB(
+                    coordinates=old_coordinates,
+                    elements=old_elements,
+                    marked_elements=marked_elements,
+                    boundary_conditions=old_boundaries)
+            stiffness_matrix = csr_matrix(get_stiffness_matrix(
+                coordinates=new_coordinates, elements=new_elements))
+            
+            u = evaluate_on_coordinates(
+                u=u,
+                elements=old_elements,
+                coordinates=old_coordinates,
+                r=new_coordinates)
+            
+            current_a_norm_squared = u.dot(stiffness_matrix.dot(u))
+
+            self.assertAlmostEqual(
+                initial_a_norm_squared,
+                current_a_norm_squared
+            )
+
+            old_coordinates = new_coordinates
+            old_elements = new_elements
+            old_boundaries = new_boundaries
+
+
+def get_initial_mesh() -> tuple[
+        ElementsType, CoordinatesType, BoundaryType]:
+    """
+    returns a coarse initial unit square mesh
+    """
+    coordinates = np.array([
+        [0., 0.],
+        [1., 0.],
+        [1., 1.],
+        [0., 1.]
+    ])
+
+    elements = np.array([
+        [0, 1, 2],
+        [0, 2, 3]
+    ])
+
+    boundary = np.array([
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 0]
+    ])
+    boundaries = [boundary]
+
+    return elements, coordinates, boundaries
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/p1afempy/tests/auto/test_get_weighted_mass_matrix.py
+++ b/p1afempy/tests/auto/test_get_weighted_mass_matrix.py
@@ -92,7 +92,6 @@ class WeightedMassMatrixTest(unittest.TestCase):
             exact_result = get_exact_result(
                 coefficients=coefficients,
                 u_star=Uh_star)
-            print(exact_result)
 
             self.assertAlmostEqual(numerical_result, exact_result)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
   "pathlib",
   "matplotlib",
   "ismember>=1.0.4",
-  "triangle-cubature"
+  "triangle-cubature",
+  "tqdm"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "p1afempy"
-version = "0.2.15"
+version = "0.2.16"
 authors = [
   { name="Raphael Leu", email="raphaelleu95@gmail.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 ismember>=1.0.4
 triangle-cubature
 sympy
+tqdm


### PR DESCRIPTION
This PR

- implements the function `evaluate_on_coordinates` that allows the evaluate on any P1FEM function on a set of admissible coordinates, i.e., points that lie in the domain $\Omega$